### PR TITLE
The paddle test models for openvino unit test.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,7 @@
 *.yuv filter=lfs diff=lfs merge=lfs -text
 *.bmp filter=lfs diff=lfs merge=lfs -text
 *.prototxt filter=lfs diff=lfs merge=lfs -text
+*.pdmodel filter=lfs diff=lfs merge=lfs -text
+*.pdiparams filter=lfs diff=lfs merge=lfs -text
+__model__ filter=lfs diff=lfs merge=lfs -text
+W filter=lfs diff=lfs merge=lfs -text

--- a/models/test_model/paddle/paddle_legacy/W
+++ b/models/test_model/paddle/paddle_legacy/W
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd95e45ce6ebba3efb4176f592d6378a95416f6763b4c6cbf430099caa099ec9
+size 2134

--- a/models/test_model/paddle/paddle_legacy/__model__
+++ b/models/test_model/paddle/paddle_legacy/__model__
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a7e8c0b89d8603265075665cb21dfa5dc63470fdeef79150c691b9ee274e53b
+size 8877

--- a/models/test_model/paddle/test_model.pdiparams
+++ b/models/test_model/paddle/test_model.pdiparams
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd95e45ce6ebba3efb4176f592d6378a95416f6763b4c6cbf430099caa099ec9
+size 2134

--- a/models/test_model/paddle/test_model.pdmodel
+++ b/models/test_model/paddle/test_model.pdmodel
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d17ff31e02618595a4c5756e2b33170598a56f2612e0553f4b77092201f72ef
+size 9081


### PR DESCRIPTION
The paddle test models for openvino unit test.

It is used by openvinotoolkit/openvino#7663
There is no license. I create the model myself with PaddlePaddle, which is Apache v2.0. They are need for Paddle unit test for IE, just like the ones for ONNX.