### PR TITLE
CPU plugin renamed to ov_intel_cpu_plugin and moved to new place

### DIFF
--- a/ie_class/plugins.xml
+++ b/ie_class/plugins.xml
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 <ie>
     <plugins>
-        <plugin location="libMKLDNNPlugin.so" name="CUSTOM">
+        <plugin location="libov_intel_cpu_plugin.so" name="CUSTOM">
         </plugin>
     </plugins>
 </ie>

--- a/ie_class/plugins_apple.xml
+++ b/ie_class/plugins_apple.xml
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 <ie>
     <plugins>
-        <plugin location="libMKLDNNPlugin.so" name="CUSTOM">
+        <plugin location="libov_intel_cpu_plugin.so" name="CUSTOM">
         </plugin>
     </plugins>
 </ie>

--- a/ie_class/plugins_mingw.xml
+++ b/ie_class/plugins_mingw.xml
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 <ie>
     <plugins>
-        <plugin location="libMKLDNNPlugin.dll" name="CUSTOM">
+        <plugin location="libov_intel_cpu_plugin.dll" name="CUSTOM">
         </plugin>
     </plugins>
 </ie>

--- a/ie_class/plugins_win.xml
+++ b/ie_class/plugins_win.xml
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 <ie>
     <plugins>
-        <plugin location="MKLDNNPlugin.dll" name="CUSTOM">
+        <plugin location="ov_intel_cpu_plugin.dll" name="CUSTOM">
         </plugin>
     </plugins>
 </ie>


### PR DESCRIPTION
### Details:
* CPU plugin renamed to ov_intel_cpu_plugin and moved to new place

### Tickets:
* CVS-71045
Should be merged with PR 9342 to openvino repo.
The branch can be removed after a merge.